### PR TITLE
ir: drop parameters deprecated in 0.50.0

### DIFF
--- a/roles/ir/defaults/main.yml
+++ b/roles/ir/defaults/main.yml
@@ -124,14 +124,10 @@ neofs_ir__raw_config:
     address: '{{ neofs_ir__wallet_address }}'
     password: '{{ neofs_ir__wallet_password }}'
 
-  fschain_autodeploy: True
-
   node:
     persistent_state:
       path: '{{ neofs_ir__data_dir }}/state'
 
-  fee:
-    main_chain: 25000000
   emit:
     storage:
       amount: 400000000


### PR DESCRIPTION
Autodeploy is enabled by default now and fee settings are per-network anyway, having zero by default doesn't hurt much.